### PR TITLE
Upgrade to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,5 +43,5 @@ outputs:
     description: Config directory of GHCup
 
 runs:
-  using: node20
+  using: node24
   main: ghcup/dist/index.js


### PR DESCRIPTION
Fixes #20. 

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/